### PR TITLE
Feature/channel command redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ The Arduino Bot provides helpful information, troubleshooting steps, and communi
 
 All commands are used as Discord slash commands (type `/` in Discord):
 
-| Command   | Usage Example         | Description                                      |
-|-----------|----------------------|--------------------------------------------------|
-| `/about`  | `/about`             | Shows information about the bot.                 |
-| `/tag`    | `/tag name:<tag>`    | Sends an informational tag ephemerally.          |
+| Command   | Usage Example              | Description                                                        |
+|-----------|---------------------------|--------------------------------------------------------------------|
+| `/about`  | `/about`                  | Shows information about the bot.                                   |
+| `/tag`    | `/tag name:<tag> [user:@username]` | Sends an informational tag to the bot-commands channel, optionally pinging a user. |
 
 ### `/tag` options (alphabetical)
 
@@ -34,7 +34,15 @@ All commands are used as Discord slash commands (type `/` in Discord):
 - `wiki` — Link to the Arduino Discord community wiki.
 
 **Example:**  
-`/tag name:power` — Sends information about powering Arduino boards.
+`/tag name:power` — Sends information about powering Arduino boards to the bot-commands channel.
+`/tag name:avrdude user:@someuser` — Sends AVRDUDE troubleshooting info to the bot-commands channel and pings `@someuser`.
+
+## Environment Variables
+
+This bot requires the following environment variables to be set:
+
+-   `BOT_TOKEN`: Your Discord bot token.
+-   `BOT_COMMANDS_CHANNEL_ID`: The ID of the channel where the bot will send responses for commands like `/tag`. This channel should be configured in your server.
 
 ## Contributing
 

--- a/src/commands/tag.ts
+++ b/src/commands/tag.ts
@@ -69,7 +69,6 @@ export class TagCommand extends Command {
       });
     }
 
-    let messageContent: string | undefined;
     let messagePayload: any = {};
 
     if (typeof tag === 'object') {
@@ -78,19 +77,23 @@ export class TagCommand extends Command {
         messagePayload.content = `<@${user.id}>`;
       }
     } else {
-      // tag is a string
-      messageContent = tag;
-      if (user) {
-        messageContent = `<@${user.id}> ${tag}`;
-      }
-      messagePayload.content = messageContent;
+      messagePayload.content = user ? `<@${user.id}> ${tag}` : tag;
     }
 
     await botCommandsChannel.send(messagePayload);
 
-    return interaction.reply({
-      content: 'Tag information posted to the #bot-commands channel.',
-      ephemeral: true,
-    });
+    if (user) {
+      // My goal is to  Notify the user in the original channel (not ephemeral)
+      return interaction.reply({
+        content: `Hey <@${user.id}>, check the <#${BOT_COMMANDS_CHANNEL_ID}> channel for info!`,
+        ephemeral: false,
+      });
+    } else {
+      // Ephemeral reply for normal tag
+      return interaction.reply({
+        content: 'Tag information posted to the #bot-commands channel.',
+        ephemeral: true,
+      });
+    }
   }
 }

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -3,7 +3,7 @@ import 'dotenv/config';
 // TODO: zod validation would be nicer to have here
 
 // const requiredEnvironment = ['BOT_TOKEN', 'DATABASE_URL'];
-const requiredEnvironment = ['BOT_TOKEN'];
+const requiredEnvironment = ['BOT_TOKEN', 'BOT_COMMANDS_CHANNEL_ID'];
 
 const missingEnv = requiredEnvironment.filter((req) => !process.env[req]);
 
@@ -16,4 +16,5 @@ if (missingEnv.length > 0)
 export const {
   BOT_TOKEN = '',
   SERVER_ID = '420594746990526466', // default: Arduino Official
+  BOT_COMMANDS_CHANNEL_ID = 'YOUR_BOT_COMMANDS_CHANNEL_ID',
 } = process.env;

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -10,11 +10,11 @@ const missingEnv = requiredEnvironment.filter((req) => !process.env[req]);
 if (missingEnv.length > 0)
   throw new Error(
     'Missing required environment variables: \n- ' +
-      missingEnv.reduce((a, b) => (b += `\n- ${a}`))
+      missingEnv.join('\n- ')
   );
-
+// This should be the server and the bot commands channel id's.
 export const {
   BOT_TOKEN = '',
-  SERVER_ID = '420594746990526466', // default: Arduino Official
-  BOT_COMMANDS_CHANNEL_ID = 'YOUR_BOT_COMMANDS_CHANNEL_ID',
+  SERVER_ID = '420594746990526466',
+  BOT_COMMANDS_CHANNEL_ID = '451158319361556491',
 } = process.env;


### PR DESCRIPTION
This should add functionality to allow the usering calling the command to be able to use there user name of the person that the tag is FOR, and when this is done theen the bot-commands channel will post the message, but it will also ping the selected user to that channel.

The goal is to keep the bot frome being able to flood a normal help channel and when the messages gets red from google it SHOULD not have lots and lots and lots of bot command tags in the channels they should all be in Bot commands channel. 

If no user is selected then the message should just apare in the bot commands channel and there should NOT be any message redirecting the user to the commands channel.

@robherc
